### PR TITLE
Explicitly require Make use bash shell, since bash only enhancements are used.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ FS_MODULES=/opt/freeswitch/mod
 ################################
 
 ### END OF CUSTOMIZATION ###
+SHELL := /bin/bash
 PROC?=$(shell uname -m)
 
 CC=gcc 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ################################
-### FreeSwitch headers files ###
-FS_INCLUDES=/opt/freeswitch/include
-FS_MODULES=/opt/freeswitch/mod
+### FreeSwitch headers files found in libfreeswitch-dev ###
+FS_INCLUDES=/usr/include/freeswitch
+FS_MODULES=/usr/lib/freeswitch/mod
 ################################
 
 ### END OF CUSTOMIZATION ###


### PR DESCRIPTION
'Make', for FreeSWITCH's [reference](https://freeswitch.org/confluence/display/FREESWITCH/Debian+8+Jessie)  platform (Jessie) does *not* used Bash by default.  Explicitly use it. 


This fixes #6, #7, #8, and #9.


