### PR TITLE
Makefile interoperability updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,16 +8,10 @@ FS_MODULES=/usr/lib/freeswitch/mod
 SHELL := /bin/bash
 PROC?=$(shell uname -m)
 
-CC=gcc 
 CFLAGS=-fPIC -O3 -fomit-frame-pointer -fno-exceptions -Wall -std=c99 -pedantic
-ifeq (${PROC},x86_64)
-	CFLAGS+=-m64 -mtune=generic
-else
-	CFLAGS+=-m32 -march=i686
-endif
 
 INCLUDES=-I/usr/include -Ibcg729/include -I$(FS_INCLUDES)
-LDFLAGS=-lm -Wl,-static -Lbcg729/src/.libs -lbcg729 -Wl,-Bdynamic 
+LDFLAGS=-lm -Wl,-static -Lbcg729/src/.libs -lbcg729 -Wl,-Bdynamic
 
 all : mod_bcg729.o
 	$(CC) $(CFLAGS) $(INCLUDES) -shared -Xlinker -x -o mod_bcg729.so mod_bcg729.o $(LDFLAGS)
@@ -32,7 +26,7 @@ clone_bcg729:
 
 bcg729: clone_bcg729
 	cd bcg729 && sh autogen.sh && CFLAGS=-fPIC ./configure && make && cd ..
-	
+
 clean:
 	rm -f *.o *.so *.a *.la; cd bcg729 && make clean; cd ..
 


### PR DESCRIPTION
Removed unnecessary arch detection which broke builds on other platforms e.g AARCH64
Removed hardcoded gcc compiler setting as its not required, clang works just as fine

I tried to find a reason for this but found none should be safe on all systems.
(Tested on aarch64, x86_64)